### PR TITLE
Fix usage of deprecated now/0

### DIFF
--- a/app.mk
+++ b/app.mk
@@ -1,4 +1,4 @@
-VSN = 3.3.4
+VSN = 3.3.5
 
 ### Special characters
 

--- a/src/cl_dqueue.erl
+++ b/src/cl_dqueue.erl
@@ -197,7 +197,7 @@ item_extract(Dets, Key) ->
 
 
 item_insert(Dets, Item, Priority) ->
-    Key = now(),
+    Key = erlang:unique_integer([positive, monotonic]),
     ok = dets:insert(Dets, {Key, Priority, Item}),
     Key.
 
@@ -205,4 +205,3 @@ item_insert(Dets, Item, Priority) ->
 item_lookup(Dets, Key) ->
     [{Key, _Priority, Item}] = dets:lookup(Dets, Key),
     Item.
-

--- a/src/cl_queue_srv.erl
+++ b/src/cl_queue_srv.erl
@@ -51,7 +51,7 @@
 -export([code_change/3]).
 
 %%% RECORDS
--record(st, {parent, queue, in = 0, out = 0, start = now()}).
+-record(st, {parent, queue, in = 0, out = 0, start = erlang:timestamp()}).
 
 %%%-----------------------------------------------------------------------------
 %%% START/STOP EXPORTS
@@ -155,7 +155,7 @@ handle_call(count_in, _From, St) ->
 handle_call(count_out, _From, St) ->
     {reply, St#st.out, St};
 handle_call(rps_avg, _From, St) ->
-    Secs = timer:now_diff(now(), St#st.start) / 1000000,
+    Secs = timer:now_diff(erlang:timestamp(), St#st.start) / 1000000,
     {reply, round(St#st.out / Secs), St};
 handle_call(rps, From, St) ->
     _Ref = erlang:start_timer(1000, self(), {rps, From, St#st.out}),
@@ -165,7 +165,7 @@ handle_call(stop, _From, St) ->
 
 
 handle_cast(count_reset, St) ->
-    {noreply, St#st{in = 0, out = 0, start = now()}}.
+    {noreply, St#st{in = 0, out = 0, start = erlang:timestamp()}}.
 
 
 handle_info({timeout, _Ref, {rps, From, Out}}, St) ->

--- a/src/cl_timer.erl
+++ b/src/cl_timer.erl
@@ -38,10 +38,11 @@
 %%% UTILITY EXPORTS
 %%%-----------------------------------------------------------------------------
 tc(Fun) ->
-    Before = erlang:now(),
+    Before = erlang:monotonic_time(micro_seconds),
     Val = (catch Fun()),
-    After = erlang:now(),
-    {timer:now_diff(After, Before), Val}.
+    After = erlang:monotonic_time(micro_seconds),
+    Diff = After - Before,
+    {Diff, Val}.
 
 
 tc_avg(M, F, A, N) when N > 0 ->
@@ -55,7 +56,7 @@ tc_avg(M, F, A, N) when N > 0 ->
 
 
 then(TimeLapse) ->
-    {MegaSecs, Secs, MicroSecs} = now(),
+    {MegaSecs, Secs, MicroSecs} = erlang:timestamp(),
     TotalMicroSecs = MicroSecs + TimeLapse,
     SecsIncr = TotalMicroSecs div 1000000,
     MicroSecsRest = TotalMicroSecs - (SecsIncr * 1000000),
@@ -66,7 +67,7 @@ then(TimeLapse) ->
 
 
 tstamp() ->
-    {A, B, C} = now(),
+    {A, B, C} = erlang:timestamp(),
     (((A * 1000000) * 1000) + (B * 1000) + (C div 1000)).
 
 %%%-----------------------------------------------------------------------------

--- a/test/cl_consumer_SUITE.erl
+++ b/test/cl_consumer_SUITE.erl
@@ -59,7 +59,7 @@ suite() ->
 %%%-----------------------------------------------------------------------------
 init_per_suite(Conf) ->
     lists:foreach(fun(X) -> code:add_path(X) end, ct:get_config(paths, [])),
-    {A1, A2, A3} = now(),
+    {A1, A2, A3} = erlang:timestamp(),
     random:seed(A1, A2, A3),
     dbg:tracer(),
     dbg:p(all, [c, sos, sol]),
@@ -301,4 +301,3 @@ purge_stub(Stub) ->
 send_junk(Pid) ->
     {links, L} = process_info(Pid, links),
     lists:foreach(fun(X) -> X ! junk end, [Pid | L]).
-

--- a/test/cl_dqueue_SUITE.erl
+++ b/test/cl_dqueue_SUITE.erl
@@ -52,7 +52,7 @@ suite() ->
 
 init_per_suite(Config) ->
     lists:foreach(fun(X) -> code:add_path(X) end, ct:get_config(paths)),
-    {A1, A2, A3} = now(),
+    {A1, A2, A3} = erlang:timestamp(),
     random:seed(A1, A2, A3),
     start_dbg(),
     File = ct:get_config(file),
@@ -228,7 +228,7 @@ disk_usage() ->
     [{userdata, [{doc, "Tests that dqueue conforms with disk usage restrictions."}]}].
 
 disk_usage(Config) ->
-    {A1,A2,A3} = now(),
+    {A1,A2,A3} = erlang:timestamp(),
     random:seed(A1, A2, A3),
     Max = ?config(max_operations, Config),
     {ok, Q1} = cl_dqueue:open(?config(file, Config)),
@@ -267,7 +267,7 @@ disk_usage(Config) ->
 in(Q, 0) ->
     Q;
 in(Q, N) ->
-    in(cl_dqueue:in(now(), Q, random:uniform(10) - 1), N - 1).
+    in(cl_dqueue:in(erlang:timestamp(), Q, random:uniform(10) - 1), N - 1).
 
 
 in_out(Q, 0) ->
@@ -275,7 +275,7 @@ in_out(Q, 0) ->
 in_out(Q1, Times) ->
     case random:uniform(2) of
         1 ->
-            Q2 = cl_dqueue:in(now(), Q1, random:uniform(10) - 1),
+            Q2 = cl_dqueue:in(erlang:timestamp(), Q1, random:uniform(10) - 1),
             in_out(Q2, Times - 1);
         2 ->
             {_, Q2} = cl_dqueue:out(Q1),

--- a/test/cl_pool_SUITE.erl
+++ b/test/cl_pool_SUITE.erl
@@ -47,7 +47,7 @@ suite() ->
 %%%-----------------------------------------------------------------------------
 init_per_suite(Conf) ->
     lists:foreach(fun(X) -> code:add_path(X) end, ct:get_config(paths, [])),
-    {A1, A2, A3} = now(),
+    {A1, A2, A3} = erlang:timestamp(),
     random:seed(A1, A2, A3),
     dbg:tracer(),
     dbg:p(all, [c, sos, sol]),

--- a/test/cl_queue_SUITE.erl
+++ b/test/cl_queue_SUITE.erl
@@ -51,7 +51,7 @@ suite() ->
 
 init_per_suite(Config) ->
     lists:foreach(fun(X) -> code:add_path(X) end, ct:get_config(paths)),
-    {A1, A2, A3} = now(),
+    {A1, A2, A3} = erlang:timestamp(),
     random:seed(A1, A2, A3),
     start_dbg(),
     File = ct:get_config(file),
@@ -227,7 +227,7 @@ performance(Config) ->
 in(Q, 0) ->
     Q;
 in(Q, N) ->
-    in(cl_queue:in(now(), Q, random:uniform(10) - 1), N - 1).
+    in(cl_queue:in(erlang:timestamp(), Q, random:uniform(10) - 1), N - 1).
 
 
 in_out(Q, 0) ->
@@ -235,7 +235,7 @@ in_out(Q, 0) ->
 in_out(Q1, Times) ->
     case random:uniform(2) of
         1 ->
-            Q2 = cl_queue:in(now(), Q1, random:uniform(10) - 1),
+            Q2 = cl_queue:in(erlang:timestamp(), Q1, random:uniform(10) - 1),
             in_out(Q2, Times - 1);
         2 ->
             {_, Q2} = cl_queue:out(Q1),

--- a/test/cl_queue_srv_SUITE.erl
+++ b/test/cl_queue_srv_SUITE.erl
@@ -65,7 +65,7 @@ suite() ->
 %%%-----------------------------------------------------------------------------
 init_per_suite(Conf) ->
     lists:foreach(fun(X) -> code:add_path(X) end, ct:get_config(paths, [])),
-    {A1, A2, A3} = now(),
+    {A1, A2, A3} = erlang:timestamp(),
     random:seed(A1, A2, A3),
     dbg:tracer(),
     dbg:p(all, [c, sos, sol]),
@@ -244,7 +244,7 @@ in_out(Pid, 0) ->
 in_out(Pid, Times) ->
     case random:uniform(2) of
         1 ->
-            ok = cl_queue_srv:in(Pid, now(), random:uniform(10) - 1),
+            ok = cl_queue_srv:in(Pid, erlang:timestamp(), random:uniform(10) - 1),
             in_out(Pid, Times - 1);
         2 ->
             _ = dqueue:out(Pid),


### PR DESCRIPTION
The previously widely used now/0 function has
been deprecated in favor of different functions
for specific tasks. These are things like creating
monotonically ordered integers, getting timestamps,
performing diffs on timestamps, etc.

Reference page for deprecation purpose:
http://www.erlang.org/doc/apps/erts/time_correction.html
